### PR TITLE
로그인, 회원가입, 계좌조회 스타일 수정

### DIFF
--- a/src/pages/account/AccountInquiry.jsx
+++ b/src/pages/account/AccountInquiry.jsx
@@ -74,22 +74,30 @@ function AccountInquiry() {
   return (
     <div className="px-24">
       <section>
-        <header className="flex justify-between items-center pt-10 pb-10">
+        <header className="flex justify-between items-center pt-10 pb-10 border-b border-hanaGreen ">
           <h1 className="text-6xl font-hana2 font-medium">
-            계좌 조회 페이지 입니다.
+            <span className="text-hanaGreen">계좌 조회</span> 페이지 입니다.
           </h1>
         </header>
 
-        <div className="px-20 mb-8 mt-8 d-flex flex-column">
+        <div className="px-12 pt-8 mb-8 mt-8 flex flex-col border-b border-r border-hanaGreen shadow shadow-hanaGreen h-72">
           <div>
-            <h1 className="text-5xl font-hana2 mb-5">황혜림 고객님,</h1>
-            <h2 className="text-3xl font-hana2 mb-3 ">
+            <h1 className="text-5xl font-hana2 mb-5">
+              <span className="font-semibold text-hanaGreen">황혜림</span>{" "}
+              고객님,
+            </h1>
+            <h2 className="text-3xl font-hana2 mb-3">
               매일 매일 좋은일만 가득하세요.
             </h2>
           </div>
-          <div className="text-right">
+          <div className="flex-grow"></div>{" "}
+          {/* 자식 요소들 사이의 공간을 채우기 위한 요소 */}
+          <div className="text-right mb-4">
             <h2 className="text-4xl font-hana2">
-              총 잔액: {totalBalance.toFixed(2)}
+              총 잔액:{" "}
+              <span className="font-semibold text-hanaGreen">
+                {totalBalance.toFixed(0)} 원
+              </span>
             </h2>
           </div>
         </div>

--- a/src/pages/account/AccountInquiry.jsx
+++ b/src/pages/account/AccountInquiry.jsx
@@ -74,32 +74,34 @@ function AccountInquiry() {
   return (
     <div className="px-24">
       <section>
-        <header className="flex justify-between items-center pt-10">
-          <h1 className="text-5xl font-hana2 font-medium">계좌 조회</h1>
+        <header className="flex justify-between items-center pt-10 pb-10">
+          <h1 className="text-6xl font-hana2 font-medium">
+            계좌 조회 페이지 입니다.
+          </h1>
         </header>
 
         <div className="px-20 mb-8 mt-8 d-flex flex-column">
           <div>
-            <h1 className="text-3xl font-hana2 mb-5">김할배 고객님,</h1>
-            <h2 className="text-2xl font-hana2 mb-3 ">
+            <h1 className="text-5xl font-hana2 mb-5">황혜림 고객님,</h1>
+            <h2 className="text-3xl font-hana2 mb-3 ">
               매일 매일 좋은일만 가득하세요.
             </h2>
           </div>
           <div className="text-right">
-            <h2 className="text-3xl font-bold font-hana2">
+            <h2 className="text-4xl font-hana2">
               총 잔액: {totalBalance.toFixed(2)}
             </h2>
           </div>
         </div>
       </section>
-      <section className="my-4">
+      <section className="my-4 py-4">
         <div className="mb-8">
           <div className="flex justify-between items-center">
-            <h2 className="text-3xl font-semibold pb-5">
+            <h2 className="text-5xl font-semibold pb-5">
               예금({accounts.예금.length})
             </h2>
             <button
-              className="bg-hanaGreen px-4 py-2 rounded"
+              className="bg-hanaRed px-4 py-2 rounded"
               onClick={() => setShowDeposit(!showDeposit)}
             >
               {showDeposit ? (
@@ -148,11 +150,11 @@ function AccountInquiry() {
 
         <div className="mb-8">
           <div className="flex justify-between items-center">
-            <h2 className="text-3xl font-semibold pb-5">
+            <h2 className="text-5xl font-semibold pb-5">
               적금({accounts.적금.length})
             </h2>
             <button
-              className="bg-hanaGreen px-4 py-2 rounded"
+              className="bg-hanaRed px-4 py-2 rounded"
               onClick={() => setShowSavings(!showSavings)}
             >
               {showSavings ? (
@@ -201,11 +203,11 @@ function AccountInquiry() {
 
         <div className="mb-8">
           <div className="flex justify-between items-center">
-            <h2 className="text-3xl font-semibold pb-5">
+            <h2 className="text-5xl font-semibold pb-5">
               입출금({accounts.입출금.length})
             </h2>
             <button
-              className="bg-hanaGreen px-4 py-2 rounded"
+              className="bg-hanaRed px-4 py-2 rounded"
               onClick={() => setShowChecking(!showChecking)}
             >
               {showChecking ? (

--- a/src/pages/account/AccountInquiryCard.jsx
+++ b/src/pages/account/AccountInquiryCard.jsx
@@ -2,40 +2,40 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 
 function AccountInquiryCard({ account }) {
-	const navigate = useNavigate();
+  const navigate = useNavigate();
 
-	const navigateToPurchase = () => {
-		navigate("/account/detail");
-	};
+  const navigateToPurchase = () => {
+    navigate("/account/detail");
+  };
 
-	return (
-		<div className="d-flex flex-column bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
-			<div className="text-center">
-				<h5 className="mt-3 text-4xl font-hana2 font-bold tracking-tight text-gray-900 dark:text-white">
-					{account.number}
-				</h5>
-				<p className="mb-3 font-hana2 text-2xl text-gray-700 dark:text-gray-400">
-					{account.name}
-				</p>
-			</div>
-			<div className="text-center mx-3">
-				<p className="font-hana2 text-gray-700 text-3xl dark:text-gray-400">
-					잔액 : {account.balance} 원
-				</p>
-			</div>
-			<div className="flex justify-center space-x-2 pb-2">
-				<button
-					onClick={navigateToPurchase}
-					className="mt-5 mb-2 px-4 py-2 text-2xl font-hana2 text-center text-white bg-hanaGreen rounded-lg"
-				>
-					조회
-				</button>
-				<button className="mt-5 mb-2 px-4 py-2 text-2xl font-hana2 text-center text-white bg-hanaGreen rounded-lg">
-					이체
-				</button>
-			</div>
-		</div>
-	);
+  return (
+    <div className="d-flex flex-column bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
+      <div className="text-center">
+        <h5 className="mt-3 text-5xl font-hana2 font-bold tracking-tight text-gray-900 dark:text-white">
+          {account.number}
+        </h5>
+        <p className="mb-3 font-hana2 text-3xl text-gray-700 dark:text-gray-400">
+          {account.name}
+        </p>
+      </div>
+      <div className="text-center mx-3">
+        <p className="font-hana2 text-gray-700 text-4xl dark:text-gray-400">
+          잔액 : {account.balance} 원
+        </p>
+      </div>
+      <div className="flex justify-center space-x-2 pb-2">
+        <button
+          onClick={navigateToPurchase}
+          className="mt-5 mb-2 px-4 py-2 text-3xl font-hana2 text-center text-white bg-hanaRed rounded-lg"
+        >
+          조회
+        </button>
+        <button className="mt-5 mb-2 px-4 py-2 text-3xl font-hana2 text-center text-white bg-hanaRed rounded-lg">
+          이체
+        </button>
+      </div>
+    </div>
+  );
 }
 
 export default AccountInquiryCard;

--- a/src/pages/account/AccountInquiryCard.jsx
+++ b/src/pages/account/AccountInquiryCard.jsx
@@ -9,28 +9,28 @@ function AccountInquiryCard({ account }) {
   };
 
   return (
-    <div className="d-flex flex-column bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
+    <div className="d-flex flex-column w-auto px-4 bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
       <div className="text-center">
-        <h5 className="mt-3 text-5xl font-hana2 font-bold tracking-tight text-gray-900 dark:text-white">
+        <h5 className="mt-4 text-5xl font-hana2 font-bold tracking-tight text-gray-900 dark:text-white">
           {account.number}
         </h5>
-        <p className="mb-3 font-hana2 text-3xl text-gray-700 dark:text-gray-400">
+        <p className="mb-4 mt-4 font-hana2 text-3xl text-gray-700 dark:text-gray-400">
           {account.name}
         </p>
       </div>
-      <div className="text-center mx-3">
+      <div className="text-center mx-4">
         <p className="font-hana2 text-gray-700 text-4xl dark:text-gray-400">
           잔액 : {account.balance} 원
         </p>
       </div>
-      <div className="flex justify-center space-x-2 pb-2">
+      <div className="flex justify-center space-x-4 pb-4">
         <button
           onClick={navigateToPurchase}
-          className="mt-5 mb-2 px-4 py-2 text-3xl font-hana2 text-center text-white bg-hanaRed rounded-lg"
+          className="flex-1 mt-4 mb-2 px-4 py-2 text-4xl font-hana2 text-center text-white bg-hanaRed rounded-lg"
         >
           조회
         </button>
-        <button className="mt-5 mb-2 px-4 py-2 text-3xl font-hana2 text-center text-white bg-hanaRed rounded-lg">
+        <button className="flex-1 mt-4 mb-2 px-4 py-2 text-4xl font-hana2 text-center text-white bg-hanaRed rounded-lg">
           이체
         </button>
       </div>

--- a/src/pages/user/Identify.jsx
+++ b/src/pages/user/Identify.jsx
@@ -19,41 +19,42 @@ function Identify({ onIdentifySuccess }) {
     <div className="container mx-auto p-10 mt-6 mb-6 bg-white rounded-xl shadow-xl">
       <header>
         <h2 className="font-hana2 font-semibold text-6xl py-10">
-          회원가입을 위한 본인인증 단계입니다.
+          회원가입을 위한 <span className="text-hanaGreen">본인인증</span>{" "}
+          단계입니다.
         </h2>
         <hr />
       </header>
       <h2 className="font-hana font-bold text-5xl mb-6 text-center pt-10 pb-10">
         본인인증
       </h2>
-      <form className="space-y-12">
+      <form className="space-y-28">
         <div className="relative h-16 w-full min-w-[200px]">
           <input
             placeholder=""
             className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-5xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
           />
-          <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-10 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
+          <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-12 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
             이름을 입력해주세요.
           </label>
         </div>
 
         <div className="flex space-x-4">
-          <div className="relative h-16 w-full min-w-[100px]">
+          <div className="relative h-16 w-full min-w-[100px] space-y-8">
             <input
               placeholder=""
               className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-5xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
             />
-            <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-10 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
+            <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-20 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
               주민등록번호 앞자리를 입력해주세요.
             </label>
           </div>
-          <div className="relative h-16 w-full min-w-[100px]">
+          <div className="relative h-16 w-full min-w-[100px] space-y-8">
             <input
               placeholder=""
               type="password"
               className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-5xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
             />
-            <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-10 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
+            <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-20 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
               주민등록번호 뒷자리를 입력해주세요.
             </label>
           </div>
@@ -67,7 +68,7 @@ function Identify({ onIdentifySuccess }) {
             placeholder=""
             className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-5xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
           />
-          <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-10 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
+          <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-12 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
             전화번호를 입력해주세요.
           </label>
         </div>

--- a/src/pages/user/Identify.jsx
+++ b/src/pages/user/Identify.jsx
@@ -1,42 +1,73 @@
-import React from "react";
+import React, { useState } from "react";
 
 function Identify({ onIdentifySuccess }) {
   const handleIdentifyClick = () => {
     // 본인인증 로직을 추가한 후 성공 시 onIdentifySuccess 호출
     onIdentifySuccess();
   };
+
+  const [phoneNum, setPhoneNum] = useState("");
+
+  const handleMobile = (e) => {
+    const regex = /^[0-9]{0,13}$/;
+    if (regex.test(e.target.value)) {
+      setPhoneNum(e.target.value);
+    }
+  };
+
   return (
-    <div className="container mx-auto max-w-md p-10 mt-6 mb-6 bg-white rounded-xl shadow-xl">
-      <h2 className="font-hana font-bold text-4xl mb-6 text-center">
+    <div className="container mx-auto p-10 mt-6 mb-6 bg-white rounded-xl shadow-xl">
+      <header>
+        <h2 className="font-hana2 font-semibold text-6xl py-10">
+          회원가입을 위한 본인인증 단계입니다.
+        </h2>
+        <hr />
+      </header>
+      <h2 className="font-hana font-bold text-5xl mb-6 text-center pt-10 pb-10">
         본인인증
       </h2>
-      <form className="space-y-4">
-        <div class="relative h-16 w-full min-w-[200px]">
+      <form className="space-y-12">
+        <div className="relative h-16 w-full min-w-[200px]">
           <input
             placeholder=""
-            class="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-2xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
+            className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-5xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
           />
-          <label class="after:content[''] pointer-events-none absolute left-0 -top-4 flex h-full w-full select-none !overflow-visible truncate text-2xl font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-1.5 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-2xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:text-2xl peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
+          <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-10 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
             이름을 입력해주세요.
           </label>
         </div>
-        <div class="relative h-16 w-full min-w-[200px]">
-          <input
-            placeholder=""
-            class="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-2xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
-          />
-          <label class="after:content[''] pointer-events-none absolute left-0 -top-4 flex h-full w-full select-none !overflow-visible truncate text-2xl font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-1.5 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-2xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:text-2xl peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
-            주민등록번호를 입력해주세요.
-          </label>
+
+        <div className="flex space-x-4">
+          <div className="relative h-16 w-full min-w-[100px]">
+            <input
+              placeholder=""
+              className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-5xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
+            />
+            <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-10 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
+              주민등록번호 앞자리를 입력해주세요.
+            </label>
+          </div>
+          <div className="relative h-16 w-full min-w-[100px]">
+            <input
+              placeholder=""
+              type="password"
+              className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-5xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
+            />
+            <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-10 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
+              주민등록번호 뒷자리를 입력해주세요.
+            </label>
+          </div>
         </div>
 
-        <div class="relative h-16 w-full min-w-[200px]">
+        <div className="relative h-16 w-full min-w-[200px]">
           <input
-            type="tel"
+            type="text"
+            value={phoneNum}
+            onChange={handleMobile}
             placeholder=""
-            class="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-2xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
+            className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-5xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
           />
-          <label class="after:content[''] pointer-events-none absolute left-0 -top-4 flex h-full w-full select-none !overflow-visible truncate text-2xl font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-1.5 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-2xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:text-2xl peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
+          <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-10 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
             전화번호를 입력해주세요.
           </label>
         </div>
@@ -45,7 +76,7 @@ function Identify({ onIdentifySuccess }) {
           <button
             type="button"
             onClick={handleIdentifyClick}
-            className="text-white font-hana2 font-semibold text-3xl bg-hanaGreen py-3 px-8 z-10 mt-4 transition-transform transform hover:animate-bubbly rounded-lg"
+            className="col w-full text-white font-hana2 font-semibold text-5xl bg-hanaRed py-3 px-8 z-10 mt-4 transition-transform transform hover:animate-bubbly rounded-lg"
           >
             본인인증하기
           </button>
@@ -54,4 +85,5 @@ function Identify({ onIdentifySuccess }) {
     </div>
   );
 }
+
 export default Identify;

--- a/src/pages/user/Login.jsx
+++ b/src/pages/user/Login.jsx
@@ -1,66 +1,70 @@
 import React, { useState, useEffect } from "react";
 import Button from "../../components/common/Button/Button";
+import { useNavigate } from "react-router-dom";
 
 function Login() {
-	const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
 
-	useEffect(() => {
-		const timer = setTimeout(() => {
-			setIsLoading(false);
-		}, 1000);
+  const navigateToRegister = () => {
+    navigate("/register");
+  };
 
-		return () => clearTimeout(timer);
-	}, []);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsLoading(false);
+    }, 1000);
 
-	return (
-		<div className="flex-grow flex items-center justify-center h-screen p-0">
-			{isLoading ? (
-				<h1 className="text-black font-hana2 font-semibold text-6xl">
-					로그인 화면으로 이동합니다
-				</h1>
-			) : (
-				<div>
-					<div className="container mx-auto max-w-md p-10 mt-6 mb-6 bg-white rounded-xl shadow-xl">
-						<h2 className="font-hana font-bold text-4xl mb-6 text-center">
-							로그인
-						</h2>
-						<form className="space-y-4">
-							<div class="relative h-16 w-full min-w-[200px]">
-								<input
-									placeholder=""
-									class="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-2xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
-								/>
-								<label class="after:content[''] pointer-events-none absolute left-0 -top-4 flex h-full w-full select-none !overflow-visible truncate text-2xl font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-1.5 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-2xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:text-2xl peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
-									전화번호를 입력해주세요.
-								</label>
-							</div>
-							<div class="relative h-16 w-full min-w-[200px]">
-								<input
-									type="password"
-									placeholder=""
-									class="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-2xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
-								/>
-								<label class="after:content[''] pointer-events-none absolute left-0 -top-4 flex h-full w-full select-none !overflow-visible truncate text-2xl font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-1.5 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-2xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:text-2xl peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
-									비밀번호를 입력해주세요.
-								</label>
-							</div>
-							<div className="flex justify-center items-center">
-								<button className="text-white font-hana2 font-semibold text-3xl bg-hanaRed py-3 px-8 z-10 mt-4 transition-transform transform hover:animate-bubbly rounded-lg">
-									로그인
-								</button>
-							</div>
-						</form>
-					</div>
-					<div className="flex justify-center items-center">
-						계정이 없으신가요?
-						<button className="text-white font-hana2 font-semibold text-3xl bg-hanaGreen py-3 px-8 z-10 mt-4 transition-transform transform hover:animate-bubbly rounded-lg">
-							회원가입
-						</button>
-					</div>
-				</div>
-			)}
-		</div>
-	);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div className="flex-grow flex items-center justify-center h-screen p-0">
+      {isLoading ? (
+        <h1 className="text-black font-hana2 font-semibold text-6xl">
+          로그인 화면으로 이동합니다
+        </h1>
+      ) : (
+        <div className="container mx-auto p-10 mt-6 mb-6 bg-white rounded-xl shadow-xl">
+          <header className="text-center">
+            <h2 className="font-hana2 font-semibold text-6xl py-10 ">로그인</h2>
+          </header>
+          <form className="space-y-12">
+            <div className="relative h-16 w-full min-w-[200px]">
+              <input
+                placeholder=""
+                className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-5xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
+              />
+              <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-10 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
+                전화번호를 입력해주세요.
+              </label>
+            </div>
+            <div className="relative h-16 w-full min-w-[200px]">
+              <input
+                type="password"
+                placeholder=""
+                className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-5xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
+              />
+              <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-10 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
+                비밀번호를 입력해주세요.
+              </label>
+            </div>
+            <div className="flex flex-col justify-center items-center">
+              <button className="col w-full text-white font-hana2 font-semibold text-5xl bg-hanaRed py-3 px-8 z-10 mt-4 transition-transform transform hover:animate-bubbly rounded-lg">
+                로그인
+              </button>
+              <button
+                onClick={navigateToRegister}
+                className="w-full text-hanaGreen font-hana2 font-semibold text-5xl border-4 border-hanaGreen py-3 px-8 z-10 mt-4 transition-transform transform hover:animate-bubbly rounded-lg"
+              >
+                회원가입하기
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default Login;

--- a/src/pages/user/Login.jsx
+++ b/src/pages/user/Login.jsx
@@ -25,11 +25,11 @@ function Login() {
           로그인 화면으로 이동합니다
         </h1>
       ) : (
-        <div className="container mx-auto p-10 mt-6 mb-6 bg-white rounded-xl shadow-xl">
+        <div className="container mx-auto p-8 mb-12 bg-white rounded-xl shadow-xl">
           <header className="text-center">
-            <h2 className="font-hana2 font-semibold text-6xl py-10 ">로그인</h2>
+            <h2 className="font-hana2 font-semibold text-6xl py-8 ">로그인</h2>
           </header>
-          <form className="space-y-12">
+          <form className="space-y-20 mt-12">
             <div className="relative h-16 w-full min-w-[200px]">
               <input
                 placeholder=""

--- a/src/pages/user/Register.jsx
+++ b/src/pages/user/Register.jsx
@@ -18,8 +18,8 @@ function Register() {
     <div>
       {showMessage ? (
         <div className="flex items-center justify-center h-screen">
-          <h1 className="text-4xl font-hana2 font-semibold">
-            본인확인 되었습니다
+          <h1 className="text-6xl font-hana2 font-semibold">
+            본인확인 되었습니다.
           </h1>
         </div>
       ) : !isIdentified ? (

--- a/src/pages/user/RegisterForm.jsx
+++ b/src/pages/user/RegisterForm.jsx
@@ -41,7 +41,7 @@ function RegisterForm() {
       <h2 className="font-hana font-bold text-5xl mb-6 text-center pt-10 pb-10">
         회원가입
       </h2>
-      <form className="space-y-10">
+      <form className="space-y-28">
         <div className="relative h-16 w-full min-w-[200px]">
           <input
             type="password"
@@ -50,7 +50,7 @@ function RegisterForm() {
             placeholder=""
             className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-5xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
           />
-          <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-10 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
+          <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-12 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
             비밀번호를 입력해주세요.
           </label>
         </div>
@@ -62,26 +62,26 @@ function RegisterForm() {
             placeholder=""
             className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-5xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
           />
-          <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-10 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
+          <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-12 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
             비밀번호를 한 번 더 입력해주세요.
           </label>
         </div>
-        <p
+        <span
           id="password-error"
-          className={`text-red-500 font-hana2 mt-1 text-3xl ${
+          className={`text-hanaRed font-hana2 relative top-4 text-4xl ${
             passwordError ? "" : "hidden"
           }`}
         >
           비밀번호가 일치하지 않습니다.
-        </p>
-        <p
+        </span>
+        <span
           id="password-check"
-          className={`text-green-500 font-hana2 mt-1 text-3xl ${
+          className={`text-hanaGreen font-hana2 relative top-4 text-4xl ${
             passwordMatch ? "" : "hidden"
           }`}
         >
           비밀번호가 일치합니다.
-        </p>
+        </span>
 
         <div className="flex justify-center items-center">
           <button

--- a/src/pages/user/RegisterForm.jsx
+++ b/src/pages/user/RegisterForm.jsx
@@ -30,38 +30,45 @@ function RegisterForm() {
   };
 
   return (
-    <div className="container mx-auto max-w-md p-10 mt-6 mb-6 bg-white rounded-xl shadow-xl">
-      <h2 className="font-hana font-bold text-4xl mb-6 text-center">
+    <div className="container mx-auto p-10 mt-6 mb-6 bg-white rounded-xl shadow-xl">
+      <header>
+        <h2 className="font-hana2 font-semibold text-6xl py-10">
+          로그인 용 비밀번호를 입력하는 단계입니다.
+        </h2>
+        <hr />
+      </header>
+
+      <h2 className="font-hana font-bold text-5xl mb-6 text-center pt-10 pb-10">
         회원가입
       </h2>
-      <form className="space-y-4">
-        <div class="relative h-16 w-full min-w-[200px]">
+      <form className="space-y-10">
+        <div className="relative h-16 w-full min-w-[200px]">
           <input
             type="password"
             value={password}
             onChange={handlePasswordChange}
             placeholder=""
-            class="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-2xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
+            className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-5xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
           />
-          <label class="after:content[''] pointer-events-none absolute left-0 -top-4 flex h-full w-full select-none !overflow-visible truncate text-2xl font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-1.5 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-2xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:text-2xl peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
+          <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-10 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
             비밀번호를 입력해주세요.
           </label>
         </div>
-        <div class="relative h-16 w-full min-w-[200px]">
+        <div className="relative h-16 w-full min-w-[200px]">
           <input
             type="password"
             value={confirmPassword}
             onChange={handleConfirmPasswordChange}
             placeholder=""
-            class="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-2xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
+            className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 text-5xl font-hana2 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100"
           />
-          <label class="after:content[''] pointer-events-none absolute left-0 -top-4 flex h-full w-full select-none !overflow-visible truncate text-2xl font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-1.5 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-2xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:text-2xl peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
+          <label className="text-2xl after:content[''] pointer-events-none absolute left-0 -top-10 flex h-full w-full select-none !overflow-visible truncate font-hana2 leading-tight text-gray-500 transition-all after:absolute after:-bottom-3 after:block after:w-full after:scale-x-0 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-4xl peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
             비밀번호를 한 번 더 입력해주세요.
           </label>
         </div>
         <p
           id="password-error"
-          className={`text-red-500 font-hana2 mt-1 ${
+          className={`text-red-500 font-hana2 mt-1 text-3xl ${
             passwordError ? "" : "hidden"
           }`}
         >
@@ -69,7 +76,7 @@ function RegisterForm() {
         </p>
         <p
           id="password-check"
-          className={`text-green-500 font-hana2 mt-1 ${
+          className={`text-green-500 font-hana2 mt-1 text-3xl ${
             passwordMatch ? "" : "hidden"
           }`}
         >
@@ -77,8 +84,11 @@ function RegisterForm() {
         </p>
 
         <div className="flex justify-center items-center">
-          <button className="text-white font-hana2 font-semibold text-3xl bg-hanaGreen py-3 px-8 z-10 mt-4 transition-transform transform hover:animate-bubbly rounded-lg">
-            회원가입
+          <button
+            type="button"
+            className="col w-full text-white font-hana2 font-semibold text-5xl bg-hanaRed py-3 px-8 z-10 mt-4 transition-transform transform hover:animate-bubbly rounded-lg"
+          >
+            회원가입하기
           </button>
         </div>
       </form>


### PR DESCRIPTION
## 개요
글자 크기 조정 및 버튼 스타일 통일


## PR 유형
어떤 변경 사항이 있나요?

- [ ] 로그인에서 회원가입 버튼 추가 및 페이지 이동 navigate 등록
- [ ] 로그인, 회원가입, 계좌조회 페이지 글자 크기 수정
- [ ] 버튼 및 컴포넌트 색상 hanaRed로 통일

- 회원가입을 위한 본인인증 페이지 (**입력 전**)
<img width="1416" alt="스크린샷 2024-05-30 오후 8 36 07" src="https://github.com/hee-ha/hana-heritage-FE/assets/77047099/e270d160-e8c5-4a32-ac7d-a52b4e9e585d">
  
  
- 회원가입을 위한 본인인증 페이지 (**입력 후**)
<img width="800" alt="스크린샷 2024-05-30 오후 8 37 09" src="https://github.com/hee-ha/hana-heritage-FE/assets/77047099/47bd750d-47d8-4641-9cce-ba0758ad8b05">
  
  
- 본인인증 후 로그인 용 비밀번호 입력 페이지
<img width="800" alt="스크린샷 2024-05-30 오후 8 36 37" src="https://github.com/hee-ha/hana-heritage-FE/assets/77047099/d8ed0f6c-c4fb-4519-b726-a2d6ea481bf4">
  
  
- 로그인 페이지
<img width="800" alt="스크린샷 2024-05-30 오후 8 35 58" src="https://github.com/hee-ha/hana-heritage-FE/assets/77047099/81999416-c2ac-4268-bbfc-ce9b43871473">
  
  
- 계좌 조회 페이지  
<img width="800" alt="스크린샷 2024-05-30 오후 8 42 06" src="https://github.com/hee-ha/hana-heritage-FE/assets/77047099/5be29b20-b7ee-46d4-853f-03f4ac89c415">
  
  

## PR Checklist

