### PR TITLE
어드민 페이지 디테일 수정 (사이드바 선택된 메뉴 볼드처리, 로그아웃 등)

### DIFF
--- a/src/components/admin/AdminSidebar.jsx
+++ b/src/components/admin/AdminSidebar.jsx
@@ -8,12 +8,13 @@ import {
   HiMail,
   HiMailOpen,
 } from "react-icons/hi";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useLogout } from "../../hooks/useAuth";
 import { getMyInfo } from "../../apis/customer/getMyInfo";
 
-
 const AdminSidebar = () => {
+  const location = useLocation();
+
   const [name, setName] = useState("");
   const logoutMutation = useLogout();
   
@@ -29,11 +30,11 @@ const AdminSidebar = () => {
   const handleLogout = () => {
     logoutMutation.mutate();
   };
-  
+
   useEffect(() => {
     doMyInfo();
   }, []);
-  
+
   return (
     <Sidebar>
       <Sidebar.Logo
@@ -77,6 +78,10 @@ const AdminSidebar = () => {
             icon={HiPresentationChartBar}
             labelColor="dark"
             className="my-4"
+            style={{
+              fontWeight:
+                location.pathname === "/admin/settlement" ? "bold" : "normal",
+            }}
           >
             정산
           </Sidebar.Item>
@@ -86,6 +91,10 @@ const AdminSidebar = () => {
             icon={HiEmojiHappy}
             labelColor="red"
             className="my-4"
+            style={{
+              fontWeight:
+                location.pathname === "/admin/deposits-preference" ? "bold" : "normal",
+            }}
           >
             상품 선호도
           </Sidebar.Item>
@@ -94,6 +103,10 @@ const AdminSidebar = () => {
             to="/admin/inheritance-review"
             icon={HiClipboard}
             className="my-4"
+            style={{
+              fontWeight:
+                location.pathname === "/admin/inheritance-review" ? "bold" : "normal",
+            }}
           >
             상속 계약 검토 목록
           </Sidebar.Item>
@@ -102,6 +115,10 @@ const AdminSidebar = () => {
             to="/admin/consulting-review"
             icon={HiChatAlt}
             className="my-4"
+            style={{
+              fontWeight:
+                location.pathname === "/admin/consulting-review" ? "bold" : "normal",
+            }}
           >
             상담 대기 목록
           </Sidebar.Item>
@@ -110,6 +127,10 @@ const AdminSidebar = () => {
             to="/admin/sms-reservation"
             icon={HiMail}
             className="my-4"
+            style={{
+              fontWeight:
+                location.pathname === "/admin/sms-reservation" ? "bold" : "normal",
+            }}
           >
             문자 예약 발송
           </Sidebar.Item>
@@ -118,6 +139,10 @@ const AdminSidebar = () => {
             to="/admin/sms-reservation/result"
             icon={HiMailOpen}
             className="my-4"
+            style={{
+              fontWeight:
+                location.pathname === "/admin/sms-reservation/result" ? "bold" : "normal",
+            }}
           >
             문자 예약 결과
           </Sidebar.Item>

--- a/src/components/admin/AdminSidebar.jsx
+++ b/src/components/admin/AdminSidebar.jsx
@@ -1,5 +1,4 @@
-"use client";
-
+import React, { useEffect, useState } from "react";
 import { Sidebar } from "flowbite-react";
 import {
   HiPresentationChartBar,
@@ -11,14 +10,30 @@ import {
 } from "react-icons/hi";
 import { Link } from "react-router-dom";
 import { useLogout } from "../../hooks/useAuth";
+import { getMyInfo } from "../../apis/customer/getMyInfo";
 
 
 const AdminSidebar = () => {
+  const [name, setName] = useState("");
   const logoutMutation = useLogout();
+  
+  const doMyInfo = async () => {
+    try {
+      const response = await getMyInfo();
+      setName(response.result.name);
+    } catch (error) {
+      console.error("Failed to fetch response:", error);
+    }
+  };
 
   const handleLogout = () => {
     logoutMutation.mutate();
   };
+  
+  useEffect(() => {
+    doMyInfo();
+  }, []);
+  
   return (
     <Sidebar>
       <Sidebar.Logo
@@ -44,7 +59,7 @@ const AdminSidebar = () => {
               </svg>
             </div>
             <h3 className="font-noto text-hanaGreen text-2xl">
-              <span className="font-bold">황혜림</span>님
+              <span className="font-bold">{name}</span>님
             </h3>
             <p className="font-noto text-gray-500">리빙트러스트 소속</p>
             <button

--- a/src/components/admin/AdminSidebar.jsx
+++ b/src/components/admin/AdminSidebar.jsx
@@ -10,8 +10,15 @@ import {
   HiMailOpen,
 } from "react-icons/hi";
 import { Link } from "react-router-dom";
+import { useLogout } from "../../hooks/useAuth";
+
 
 const AdminSidebar = () => {
+  const logoutMutation = useLogout();
+
+  const handleLogout = () => {
+    logoutMutation.mutate();
+  };
   return (
     <Sidebar>
       <Sidebar.Logo
@@ -42,6 +49,7 @@ const AdminSidebar = () => {
             <p className="font-noto text-gray-500">리빙트러스트 소속</p>
             <button
               type="button"
+              onClick={handleLogout}
               className="w-full my-4 text-gray-900 bg-white border border-gray-300 focus:outline-none hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-gray-800 dark:text-white dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:border-gray-600 dark:focus:ring-gray-700"
             >
               로그아웃

--- a/src/pages/admin/AdminHome.jsx
+++ b/src/pages/admin/AdminHome.jsx
@@ -1,6 +1,12 @@
 import React from "react";
+import { useEffect } from "react";
+import { Outlet, useNavigate } from "react-router-dom";
 
 const AdminHome = () => {
+  const navigate = useNavigate();
+  useEffect(() => {
+    navigate("/admin/settlement");
+  }, []);
   return (
     <div>
       <h1>Home</h1>


### PR DESCRIPTION
## 개요
Resolves: #95 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 어드민 로그아웃 버튼 api 연결
- [x] 사이드바에 현재 로그인된 계정 이름으로 수정
- [x] admin 홈 대신 정산 페이지로 리다이렉트
- [x] 사이드바 선택된 메뉴 볼드처리
![image](https://github.com/hee-ha/hana-heritage-FE/assets/70644449/d54d9496-ea0a-4748-9233-0e1d72f12dde)

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.
